### PR TITLE
Update pins_printrboard.h to solve Ystop problem

### DIFF
--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -3,6 +3,7 @@
  * Requires the Teensyduino software with Teensy++ 2.0 selected in Arduino IDE!
  * http://www.pjrc.com/teensy/teensyduino.html
  * See http://reprap.org/wiki/Printrboard for more info
+ * If you are using an I2C SD card reader, you must move your Y endstop to the ESTOP socket
  */
 
 #ifndef __AVR_AT90USB1286__
@@ -47,7 +48,11 @@
 #endif
 
 #define X_STOP_PIN         35
-#define Y_STOP_PIN          8
+#ifdef SDSUPPORT
+   #define Y_STOP_PIN       37   // {must be 37 and us estop socket for ystop for SD card support}
+#else 
+  #define Y_STOP_PIN         8   // {Printrboard w/o I2C SD}
+#endif
 #define Z_STOP_PIN         36
 #define TEMP_0_PIN          1  // Extruder / Analog pin numbering
 #define TEMP_BED_PIN        0  // Bed / Analog pin numbering


### PR DESCRIPTION
This makes the selection of the Y_stop_pin automatically compensate for pin 8 being used for I2C communication.
I think this is a better way to deal with the problem than having the users dig down into the pins code!
